### PR TITLE
Add Support for plural mods

### DIFF
--- a/web/src/parser/visitors/explicit-visitor.ts
+++ b/web/src/parser/visitors/explicit-visitor.ts
@@ -74,6 +74,7 @@ class ExplicitVisitor implements ItemVisitor {
     let attempts = 0;
     while (remainingText.length > 0 && attempts < 20) {
       attempts++;
+      console.log("lol", remainingText);
       for (const affix of this.affixInfo) {
         const regex = new RegExp(affix.mappedRegex.source, "gm");
         const match = regex.exec(remainingText);

--- a/web/src/trade/affix-info.ts
+++ b/web/src/trade/affix-info.ts
@@ -76,7 +76,7 @@ class AffixInfoFetcher {
             .replace("increased", "(increased|reduced)")
             .replaceAll("#", "\\+?\\d+(?:\\.\\d+)?");
 
-          const mappedRegex = new RegExp(`^${transformedText}$`, "g");
+          const mappedRegex = new RegExp(`^${transformedText}(s?)$`, "g");
 
           return {
             ...entry,

--- a/web/test/chat-item-parser.test.ts
+++ b/web/test/chat-item-parser.test.ts
@@ -106,7 +106,7 @@ Item Level: 81
       {
         poe_id: "explicit.stat_3372524247",
         rawText: "+31% to Fire Resistance",
-        regex: /^\+?\d+(?:\.\d+)?% to (Resistances|Fire Resistance)$/g,
+        regex: /^\+?\d+(?:\.\d+)?% to (Resistances|Fire Resistance)(s?)$/g,
         type: "EXPLICIT",
       },
     ],
@@ -118,7 +118,7 @@ Item Level: 81
       {
         poe_id: "explicit.stat_1671376347",
         rawText: "+38% to Lightning Resistance",
-        regex: /^\+?\d+(?:\.\d+)?% to (Resistances|Lightning Resistance)$/g,
+        regex: /^\+?\d+(?:\.\d+)?% to (Resistances|Lightning Resistance)(s?)$/g,
         type: "EXPLICIT",
       },
     ],

--- a/web/test/item-parser.test.ts
+++ b/web/test/item-parser.test.ts
@@ -278,7 +278,7 @@ test("sample item 1", async () => {
       {
         poe_id: "explicit.stat_3299347043",
         rawText: "+212 to maximum Life",
-        regex: /^\+?\d+(?:\.\d+)? to maximum Life$/g,
+        regex: /^\+?\d+(?:\.\d+)? to maximum Life(s?)$/g,
         type: "EXPLICIT",
       },
     ],
@@ -306,7 +306,7 @@ test("sample item 2", async () => {
       {
         poe_id: "explicit.stat_803737631",
         rawText: "+38 to Accuracy Rating",
-        regex: /^\+?\d+(?:\.\d+)? to (Accuracy|Accuracy) Rating$/g,
+        regex: /^\+?\d+(?:\.\d+)? to (Accuracy|Accuracy) Rating(s?)$/g,
         type: "EXPLICIT",
       },
     ],
@@ -332,7 +332,7 @@ test("sample item 3", async () => {
         poe_id: "explicit.stat_3141070085",
         rawText: "15% increased Elemental Damage",
         regex:
-          /^\+?\d+(?:\.\d+)?% (increased|reduced) (ElementalDamage|Elemental Damage)$/g,
+          /^\+?\d+(?:\.\d+)?% (increased|reduced) (ElementalDamage|Elemental Damage)(s?)$/g,
         type: "EXPLICIT",
       },
     ],
@@ -364,7 +364,7 @@ test("sample item 4", async () => {
         poe_id: "explicit.stat_3917489142",
         rawText: "15% increased Rarity of Items found",
         regex:
-          /^\+?\d+(?:\.\d+)?% (increased|reduced) (ItemRarity|Rarity of Items) found$/g,
+          /^\+?\d+(?:\.\d+)?% (increased|reduced) (ItemRarity|Rarity of Items) found(s?)$/g,
         type: "EXPLICIT",
       },
     ],
@@ -399,7 +399,7 @@ test("sample item 6", async () => {
         poe_id: "explicit.stat_770672621",
         rawText: "Minions have 28% increased maximum Life",
         regex:
-          /^(Minion|Minions) have \+?\d+(?:\.\d+)?% (increased|reduced) maximum Life$/g,
+          /^(Minion|Minions) have \+?\d+(?:\.\d+)?% (increased|reduced) maximum Life(s?)$/g,
         type: "EXPLICIT",
       },
     ],
@@ -414,7 +414,7 @@ test("sample item 6", async () => {
       {
         type: "EXPLICIT",
         regex:
-          /^(Allies|Allies) in your (Presence|Presence) deal \+?\d+(?:\.\d+)? to \+?\d+(?:\.\d+)? additional (Attack|Attack) (Lightning|Lightning) Damage$/g,
+          /^(Allies|Allies) in your (Presence|Presence) deal \+?\d+(?:\.\d+)? to \+?\d+(?:\.\d+)? additional (Attack|Attack) (Lightning|Lightning) Damage(s?)$/g,
         poe_id: "explicit.stat_2854751904",
         rawText:
           "Allies in your Presence deal 1 to 10 additional Attack Lightning Damage",
@@ -445,7 +445,7 @@ test("sample item 7", async () => {
         poe_id: "explicit.stat_3169585282",
         rawText: "Allies in your Presence have +67 to Accuracy Rating",
         regex:
-          /^(Allies|Allies) in your (Presence|Presence) have \+?\d+(?:\.\d+)? to (Accuracy|Accuracy) Rating$/g,
+          /^(Allies|Allies) in your (Presence|Presence) have \+?\d+(?:\.\d+)? to (Accuracy|Accuracy) Rating(s?)$/g,
         type: "EXPLICIT",
       },
     ],
@@ -459,7 +459,7 @@ test("sample item 7", async () => {
         poe_id: "explicit.stat_1998951374",
         rawText: "Allies in your Presence have 16% increased Attack Speed",
         regex:
-          /^(Allies|Allies) in your (Presence|Presence) have \+?\d+(?:\.\d+)?% (increased|reduced) (Attack|Attack) Speed$/g,
+          /^(Allies|Allies) in your (Presence|Presence) have \+?\d+(?:\.\d+)?% (increased|reduced) (Attack|Attack) Speed(s?)$/g,
         type: "EXPLICIT",
       },
     ],
@@ -517,7 +517,7 @@ test("sample item 8", async () => {
         poe_id: "implicit.stat_1573130764",
         rawText: "Adds 3 to 5 Fire damage to Attacks",
         regex:
-          /^Adds \+?\d+(?:\.\d+)? to \+?\d+(?:\.\d+)? (Fire) damage to (Attack|Attacks)$/g,
+          /^Adds \+?\d+(?:\.\d+)? to \+?\d+(?:\.\d+)? (Fire) damage to (Attack|Attacks)(s?)$/g,
         type: "IMPLICIT",
       },
     ],
@@ -545,7 +545,7 @@ test("sample item 9", async () => {
         poe_id: "implicit.stat_2219129443",
         rawText: "5 Maps in Range contain Breaches",
         regex:
-          /^\+?\d+(?:\.\d+)? Maps in Range contain (ContainsBreach|Breaches)$/g,
+          /^\+?\d+(?:\.\d+)? Maps in Range contain (ContainsBreach|Breaches)(s?)$/g,
         type: "IMPLICIT",
       },
     ],
@@ -572,7 +572,7 @@ test("sample item 11", async () => {
         rawText:
           "When a Party Member in your Presence Casts a Spell, you\nSacrifice 20% of Mana and they Leech that Mana",
         regex:
-          /^When a Party Member in your (Presence) Casts a (Spell), you\n(Sacrifice) \+?\d+(?:\.\d+)?% of Mana and they (ManaLeech|Leech that Mana)$/g,
+          /^When a Party Member in your (Presence) Casts a (Spell), you\n(Sacrifice) \+?\d+(?:\.\d+)?% of Mana and they (ManaLeech|Leech that Mana)(s?)$/g,
         type: "EXPLICIT",
       },
     ],
@@ -630,7 +630,7 @@ Note: ~price 10 exalted`;
         poe_id: "enchant.stat_2694482655",
         rawText: "+13% to Critical Damage Bonus",
         regex:
-          /^\+?\d+(?:\.\d+)?% to (CriticalDamageBonus|Critical Damage Bonus)$/g,
+          /^\+?\d+(?:\.\d+)?% to (CriticalDamageBonus|Critical Damage Bonus)(s?)$/g,
         type: "ENCHANT",
       },
     ],
@@ -801,4 +801,48 @@ Causes 51% increased Stun Buildup`;
   expect(
     parsedSampleItem.stats?.find((f) => f.type === "total-dps")?.value,
   ).toBe(184.9);
+});
+
+test("charm mod", async () => {
+  const itemString = `Item Class: Belts
+Rarity: Rare
+Beast Shackle
+Long Belt
+--------
+Charm Slots: 3 (augmented)
+--------
+Requirements:
+Level: 54
+--------
+Item Level: 80
+--------
+15% increased Charm Effect Duration (implicit)
+--------
++161 to maximum Life
++16 to maximum Mana
++2 Charm Slots
++19% to Cold Resistance
+19.7 Life Regeneration per second
+4 to 7 Physical Thorns damage`;
+
+  const parsedSampleItem = await parse(itemString);
+
+  expect(parsedSampleItem.itemClass).toBe("Belts");
+  expect(parsedSampleItem.rarity).toBe("Rare");
+  expect(parsedSampleItem.name).toBe("Beast Shackle");
+
+  const a1 = {
+    roll: 2,
+    included: false,
+    affix: [
+      {
+        poe_id: "explicit.stat_1416292992",
+        rawText: "+2 Charm Slots",
+        regex: /^\+?\d+(?:\.\d+)? (Charm) Slot(s?)$/g,
+        type: "EXPLICIT",
+      },
+    ],
+  };
+
+  expect(parsedSampleItem.affixs).toContainEqual(a1);
 });


### PR DESCRIPTION
```
{
          "id": "explicit.stat_1416292992",
          "text": "# [Charm] Slot",
          "type": "explicit"
},
```
and yet in game it shows as `Slots`